### PR TITLE
Update git:changelog to use annotated commit messages

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -1,3 +1,14 @@
+=== 1.4.0 / 2011-05-16
+
+* 2 minor enhancements:
+
+  * Exported all the other git functions so that other rake tasks can benefit.
+  * Updated git:changelog to support annotated commit messages.
+
+* 1 bug fix:
+
+  * Fix shell escaping on Windows. [Gordon Thiesfeld]
+
 === 1.3.0 / 2009-07-27
 
 * Add a git:manifest task. [Phil Hagelb0rg]

--- a/README.rdoc
+++ b/README.rdoc
@@ -24,12 +24,15 @@ This takes all the commit messages since your last release and formats
 'em into a nice RDoc fragment. If you specify <tt>VERSION</tt>, it'll
 be used in the changelog fragment. If you specify <tt>FROM</tt>, it'll
 be used as a starting point for the changelog instead of your last
-release.
+tagged release.
 
-Commits that weren't made by a project developer will be attributed,
-like this:
+The rdoc is automatically formatted into sections by using "annotated
+commit messages" by using a simple format for multi-line commit messages:
 
-    * Did a thing with the stuff. [I R Contributor]
+    ! major change description.
+    + minor change description.
+    - bug fix description.
+    un-logged description (for minor stuff like re-formatting).
 
 === Generating the Manifest
 

--- a/lib/hoe/git.rb
+++ b/lib/hoe/git.rb
@@ -42,7 +42,7 @@ class Hoe #:nodoc:
 
       desc "Print the current changelog."
       task "git:changelog" do
-        tag   = ENV["FROM"] || Hoe::Git.git_tags.last
+        tag   = ENV["FROM"] || git_tags.last
         range = [tag, "HEAD"].compact.join ".."
         cmd   = "git log #{range} '--format=tformat:%B|||%aN|||%aE|||'"
         now   = Time.new.strftime "%Y-%m-%d"
@@ -177,7 +177,5 @@ class Hoe #:nodoc:
       end
       puts
     end
-
-    module_function :git_tags, :git_svn?, :git_release_tag_prefix, :changelog_section
   end
 end

--- a/lib/hoe/git.rb
+++ b/lib/hoe/git.rb
@@ -20,7 +20,7 @@ class Hoe #:nodoc:
   module Git
 
     # Duh.
-    VERSION = "1.3.0"
+    VERSION = "1.4.0"
 
     # What do you want at the front of your release tags?
     # [default: <tt>"v"</tt>]


### PR DESCRIPTION
This should have been in there years ago.
