### PR TITLE
Moves git:tag task to run during postrelease task

### DIFF
--- a/lib/hoe/git.rb
+++ b/lib/hoe/git.rb
@@ -122,7 +122,7 @@ class Hoe #:nodoc:
         end
       end
 
-      task :release_to => "git:tag"
+      task :postrelease => "git:tag"
     end
 
     def git_svn?


### PR DESCRIPTION
I don't want to create the tag until I know the push to gemserver has been successful.
